### PR TITLE
Update footer.tsx

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -5,7 +5,7 @@ import { SOCIAL_LIST } from '@/components/socials';
 
 export default function Footer() {
     return (
-        <footer className="w-screen bg-slate-900 px-10 py-7">
+        <footer className="w-full bg-slate-900 px-10 py-7">
             <div className='flex items-center justify-center'>
                 {SOCIAL_LIST.map((item) => (
                     <SocialLink key={item.alt} src={item.src} alt={item.alt} href={item.href} />


### PR DESCRIPTION
Changing footer width from `w-screen` to `w-full` fixes a small bug in the website that makes the footer wider than the screen resulting in a horizontal scroll bar as can be seen here: https://imgur.com/a/VJZlET7

![Screenshot 2023-12-27 140643](https://github.com/TolleyLikesRice/tolley.dev/assets/78003275/932cdbd3-b7e5-4636-ac83-12342f8d10d1)